### PR TITLE
Solr docker image with liresolr installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8
+COPY . /liresolr
+WORKDIR /liresolr
+RUN ./gradlew distForSolr
+
+FROM solr:7-alpine
+COPY --from=0 /liresolr/dist/lire*.jar /opt/solr/server/solr-webapp/webapp/WEB-INF/lib/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  solr:
+    build: .
+    ports:
+      - 8983:8983


### PR DESCRIPTION
In the end I decided not to include the solr config, it's probably better to install them as core-specific config.

Might be helpful to setup DockerHub auto-build for this repo so the image is accessible on DockerHub.