### PR TITLE
Add option to disable orderHashes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-#Thu Apr 28 09:39:17 UTC 2022
-versionString=8.11.1_b01
-buildDate=2022-04-28-0939
-buildNumber=599
+#Thu Sep 15 04:50:43 CST 2022
+versionString=8.11.1_b02
+buildDate=2022-09-15-0450
+buildNumber=600


### PR DESCRIPTION
Problem: 

The current version of liresolr is having an issue extracting hashes for a given picture. There are two ways to generate hashes with liresolr, one is by using the command line to call the class [net.semanticmetadata.lire.solr.indexing.ParallelSolrIndexer](https://github.com/soruly/liresolr/blob/ce9f16fa69185d26bd526326b5626a989fbfe17c/src/main/java/net/semanticmetadata/lire/solr/indexing/ParallelSolrIndexer.java#L455), and the other, as described by Dr. Mathias Lux at his official liresolr readme, using the restful API *lireq?extract=http:://url.to/image.png&field=eh* to call the class [LireRequestHandler](https://github.com/soruly/liresolr/blob/ce9f16fa69185d26bd526326b5626a989fbfe17c/src/main/java/net/semanticmetadata/lire/solr/LireRequestHandler.java#L501), and he explained that ``the return values for bs_list and ms_list are ordered by ascending document frequency (BitSampling) and distance from the image to the respective reference point.``

Hence, for some purposes, when a naive user like me first uses the command line to get hashes and then wants to use the restful API to get identical hashes for an exact picture, it would not work, because LireRequestHandler does not treat the picture stateless like ParallelSolrIndexer but performs post-operation to order the images hashes. Although the [post-orderHashes](https://github.com/soruly/liresolr/blob/ce9f16fa69185d26bd526326b5626a989fbfe17c/src/main/java/net/semanticmetadata/lire/solr/LireRequestHandler.java#L502) operation is good for search, from my understanding, it would cause some puzzles for users who want to extract hashes. 

Approach: 

add a parameter option 'oh' to the restful API, indicating whether to use the post-orderHashes operation and by default is true. When false, run arrayToListString instead of orderHasehs. 

![image](https://user-images.githubusercontent.com/27696701/190925162-8bb72947-d7e0-44d4-bb0f-f1d5dd88ad8f.png)


